### PR TITLE
Allow specifying a Protocol and Hostname in the config, used for redirect rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Default configuration is as follows:
 ```typescript
 {
     bucketName: '',
+    region: undefined,
+    protocol: undefined,
+    hostname: undefined,
     params: {},
     mergeCachingParams: true,
     generateRoutingRules: true,
@@ -83,7 +86,7 @@ Default configuration is as follows:
 
 Read the full spec with explanation of each field here:  
 
-https://github.com/jariz/gatsby-plugin-s3/blob/master/src/constants.ts#L15-L49
+https://github.com/jariz/gatsby-plugin-s3/blob/master/src/constants.ts#L15-L55
 
 ## Recipes
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,12 @@ export interface PluginOptions {
     // If not specified: will default to whatever the AWS SDK decides is the default otherwise
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-environment-variable
     region?: string,
+
+    // The protocol & hostname of your site
+    // If you are using a CDN or reverse-proxy (such as CloudFront) in front of S3 then you must fill out these fields to ensure redirects work correctly
+    // If you are just using your S3 website directly, this is unnecessary
+    protocol?: "http" | "https",
+    hostname?: string,
     
     // Custom params to apply to your files
     // see all available params here: 


### PR DESCRIPTION
Fixes #8 

Currently if you have CloudFront in front of S3, redirects won't work correctly. If your CF distribution is at "https://www.example.com", navigating to "https://www.example.com/test-redirect/" will redirect you to "http://www.example.com.s3-website-us-east-1.amazonaws.com". This is due to the fact that S3 specifies the absolute URL for the `Location` header, and CloudFront passes it through unchanged.

This improvement allows (optionally) specifying protocol & hostname values in the config. These are added to all redirect rules. These allow the absolute Location URLs to include a different domain from the bucket's Static Website Hosting Endpoint.

If the extra values are not specified, the current behaviour is preserved.