### PR TITLE
Allow uploading objects without an ACL

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -118,7 +118,7 @@ const deploy = async ({ yes }: { yes: boolean }) => {
         if (!exists) {
             let params: S3.Types.CreateBucketRequest = {
                 Bucket: config.bucketName,
-                ACL: config.acl || 'public-read'
+                ACL: config.acl === null ? undefined : (config.acl || 'public-read')
             };
             if (config.region) {
                 params['CreateBucketConfiguration'] = {
@@ -178,7 +178,7 @@ const deploy = async ({ yes }: { yes: boolean }) => {
                     Bucket: config.bucketName,
                     ContentType: mime.getType(key) || 'application/octet-stream',
                     ContentMD5: createHash('md5').update(buffer).digest('base64'),
-                    ACL: config.acl || 'public-read',
+                    ACL: config.acl === null ? undefined : (config.acl || 'public-read'),
                     ...getParams(key, params)
                 }).promise();
                 promises.push(promise);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ export interface PluginOptions {
     params?: Params,
 
     // Define bucket ACL, defaults to 'public-read'
-    acl?: BucketCannedACL;
+    acl?: null | BucketCannedACL;
 
     // Enable gatsby recommended caching settings
     mergeCachingParams?: boolean,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,7 @@ export interface PluginOptions {
     params?: Params,
 
     // Define bucket ACL, defaults to 'public-read'
+    // If you don't want to use an ACL, set this to null
     acl?: null | BucketCannedACL;
 
     // Enable gatsby recommended caching settings


### PR DESCRIPTION
Closes #7 

Currently it's not possible to avoid setting an ACL on uploaded files, as if you specify `undefined` or `null` in the config then the default of "public-read" will be used instead.

With this change, if the user explicitly specifies `null` then an ACL will not be set. Users can specify `undefined` or omit the acl property from their config to use the default value.

This is primarily useful because it means that the IAM policy only has to include PutObject, and not PutObjectAcl. Also, Amazon recommends against using object ACLs, as they are legacy. Bucket policies are recommended instead.