### PR TITLE
Fix wrong config filename in .env example

### DIFF
--- a/recipes/with-dotenv.md
+++ b/recipes/with-dotenv.md
@@ -20,7 +20,7 @@ AWS_SECRET_ACCESS_KEY=xxxx
 S3_BUCKET_NAME=my-bucket-name
 ```
 ```js
-// gatsby-node.js
+// gatsby-config.js
 plugins: [
   {
       resolve: `gatsby-plugin-s3`,


### PR DESCRIPTION
Change `gatsby-node.js` to `gatsby-config.js`