### PR TITLE
exit with code 1 on deploy in case of an error

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -227,6 +227,7 @@ const deploy = async ({ yes }: { yes: boolean }) => {
     catch (ex) {
         spinner.fail('Failed.');
         console.error(pe.render(ex));
+        process.exit(1);
     }
 };
 


### PR DESCRIPTION
Currently if deploy fails for any reason the process will exit with code 0. This means that on CI the job will go green. I'd assume this is not an intended behavior. Does it make sense to you?