### PR TITLE
Fix website URL in console message

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -23,6 +23,8 @@ import { createHash } from 'crypto';
 import isCI from 'is-ci';
 import { parallelLimit, asyncify, AsyncFunction } from 'async';
 
+import { getS3WebsiteDomainUrl } from './util';
+
 const cli = yargs();
 const pe = new PrettyError();
 
@@ -257,10 +259,11 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
 
         spinner.succeed('Synced.');
 
+        const s3WebsiteDomain = getS3WebsiteDomainUrl(region || 'us-east-1');
         console.log(chalk`
         {bold Your website is online at:}
-        {blue.underline http://${config.bucketName}.s3-website.${region || 'us-east-1'}.amazonaws.com}
-`);
+        {blue.underline http://${config.bucketName}.${s3WebsiteDomain}}
+        `);
     }
     catch (ex) {
         spinner.fail('Failed.');

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -259,9 +259,8 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
 
         console.log(chalk`
         {bold Your website is online at:}
-        {blue.underline http://${config.bucketName}.s3-website-${region || 'us-east-1'}.amazonaws.com}
-        `); 
-              
+        {blue.underline http://${config.bucketName}.s3-website.${region || 'us-east-1'}.amazonaws.com}
+`);
     }
     catch (ex) {
         spinner.fail('Failed.');

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,27 @@
 export const withoutLeadingSlash = (string: string) => string.startsWith('/') ? string.substring(1) : string;
 export const withoutTrailingSlash = (string: string) => string.endsWith('/') ? string.substring(0, string.length - 1) : string;
 export const withTrailingSlash = (string: string) => string.endsWith('/') ? string : (string + '/');
+
+const oldRegions: Array<string> = [
+    "ap-northeast-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "eu-west-1",
+    "sa-east-1",
+    "us-east-1",
+    "us-gov-west-1",
+    "us-west-1",
+    "us-west-2",
+];
+
+// Inspired by Terraform implementation:
+// https://github.com/terraform-providers/terraform-provider-aws/blob/e18168ba0dfd860bbd8f333a93791a2a7eab41db/aws/resource_aws_s3_bucket.go#L1584-L1613
+export const getS3WebsiteDomainUrl = (region: string): string => {
+        // New regions uses different syntax for website endpoints
+        // http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
+        if (oldRegions.indexOf(region) !== -1) {
+            return `s3-website-${region}.amazonaws.com`;
+        } else {
+            return `s3-website.${region}.amazonaws.com`;
+        }
+};


### PR DESCRIPTION
The URL constructed for the console message `Your website is online at: [...]` **has a dash instead of a dot, leading to non-working URL** in the message, despite the deployment to S3 working perfectly.

This PR fixes this.

Maybe a cleaner fix would be to avoid constructing the website URL by concatenating strings, and instead getting it from the S3 API through a Describe call or equivalent. I might submit another PR in this way if I keep using this plugin, which I probably will :slightly_smiling_face: 