### PR TITLE
Don't apply public-read ACL by default #41 & ditch object ACL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,36 @@ Requires very little configuration, while optimizing your site as much as possib
 
 ## Usage
 
-Install the plugin:
+### Installation
+
 ```bash
 npm i gatsby-plugin-s3
 ```
 
-Add it to your `gatsby-config.js` & configure the bucket name (required)
+### Configuration
+
+Add the plugin to your `gatsby-config.js` & configure the bucket name and ACL (required):
+
 ```js
 plugins: [
   {
       resolve: `gatsby-plugin-s3`,
       options: {
-          bucketName: 'my-website-bucket'
+          bucketName: 'my-website-bucket',
+          ACL: 'public-read'
       },
   },
 ]
 ```
-_There are more fields that can be configured, see below._
 
-Add a deployment script to your `package.json`
+Optionally, set the ACL to `null` if you wish to keep your bucket private (which is the default).  
+Note that your site will not be viewable by anyone but you if you do so.  
+Read [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) about all available ACL's.
+
+### Deployment
+
+Add a deployment script to your `package.json`:
+
 ```json
 "scripts": {
     ...
@@ -54,27 +65,6 @@ Optionally you can skip the confirmation prompt automatically by adding `--yes` 
 When `gatsby-plugin-s3` detects a [CI](https://en.wikipedia.org/wiki/Continuous_integration) environment, it will automatically skip this prompt by default.
 
 After configuring credentials (see below), you can now execute `npm run build && npm run deploy` to have your site be build and immediately deployed to S3.
-
-## Credentials
-
-### Globally
-
-A couple of different methods of specifying credentials exist, the easiest one being using the AWS CLI:
-
-```bash
-# NOTE: ensure python is installed
-pip install awscli
-aws configure
-```
-
-### Environment variables
-If you don't want to have your credentials saved globally (i.e. you're dealing with multiple tokens on the same environment), [they can be set as environment variables](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html), for example:
-
-```bash
-AWS_ACCESS_KEY_ID=xxxx AWS_SECRET_ACCESS_KEY=xxxx npm run deploy
-```
-
-Additionally, these can be set in a local `.env` file too, but this requires a bit more setup work. [See the recipe here](recipes/with-dotenv.md).
 
 ## Configuration
 Most of the aspects of the plugin can be configured.  

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ plugins: [
       resolve: `gatsby-plugin-s3`,
       options: {
           bucketName: 'my-website-bucket',
-          ACL: 'public-read'
+          acl: 'public-read'
       },
   },
 ]

--- a/examples/with-redirects/package-lock.json
+++ b/examples/with-redirects/package-lock.json
@@ -6139,7 +6139,6 @@
         "pretty-error": "^2.1.1",
         "stream-progressbar": "^1.1.1",
         "stream-to-promise": "^2.2.0",
-        "ts-jest": "^23.10.5",
         "yargs": "^12.0.5"
       },
       "dependencies": {
@@ -8925,8 +8924,7 @@
           "dependencies": {
             "get-stream": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "pump": "^3.0.0"
@@ -8975,8 +8973,7 @@
           "dependencies": {
             "camelcase": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-              "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+              "bundled": true,
               "optional": true
             }
           }
@@ -12210,8 +12207,7 @@
           "dependencies": {
             "get-stream": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "pump": "^3.0.0"
@@ -12219,8 +12215,7 @@
             },
             "got": {
               "version": "9.6.0",
-              "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-              "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "@sindresorhus/is": "^0.14.0",
@@ -12238,14 +12233,12 @@
             },
             "prepend-http": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-              "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+              "bundled": true,
               "optional": true
             },
             "url-parse-lax": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-              "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "prepend-http": "^2.0.0"
@@ -12906,8 +12899,7 @@
           "dependencies": {
             "mem": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-3.0.1.tgz",
-              "integrity": "sha512-QKs47bslvOE0NbXOqG6lMxn6Bk0Iuw0vfrIeLykmQle2LkCw1p48dZDdzE+D88b/xqRJcZGcMNeDvSVma+NuIQ==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "mimic-fn": "^1.0.0",
@@ -14843,8 +14835,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -14853,8 +14844,7 @@
             },
             "load-json-file": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -14866,8 +14856,7 @@
             },
             "parse-json": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "error-ex": "^1.2.0"
@@ -14875,8 +14864,7 @@
             },
             "path-exists": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "pinkie-promise": "^2.0.0"
@@ -14884,8 +14872,7 @@
             },
             "path-type": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -14895,13 +14882,11 @@
             },
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+              "bundled": true
             },
             "read-pkg": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "load-json-file": "^1.0.0",
@@ -14911,8 +14896,7 @@
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "find-up": "^1.0.0",
@@ -14921,8 +14905,7 @@
             },
             "strip-bom": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "is-utf8": "^0.2.0"
@@ -15362,8 +15345,7 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -15371,8 +15353,7 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "bundled": true,
               "optional": true
             }
           }
@@ -16799,20 +16780,17 @@
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "bundled": true,
               "optional": true
             },
             "object-keys": {
               "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+              "bundled": true,
               "optional": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -16823,14 +16801,12 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "bundled": true,
               "optional": true
             },
             "through2": {
               "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-              "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "readable-stream": "~1.1.9",
@@ -16839,8 +16815,7 @@
             },
             "xtend": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "object-keys": "~0.4.0"
@@ -17977,8 +17952,7 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -17986,8 +17960,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,8 +36,9 @@ export interface PluginOptions {
     // },
     params?: Params,
 
-    // Define bucket ACL, defaults to 'public-read'
-    // If you don't want to use an ACL, set this to null
+    // Define bucket ACL, defaults to 'private'.
+    // If you don't want to use an ACL, set this to null.
+    // WARNING: Setting this field to undefined is deprecated and will yield in a warning message.
     acl?: null | BucketCannedACL;
 
     // Enable gatsby recommended caching settings

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -23,11 +23,10 @@ const getRules = (pluginOptions: PluginOptions, routes: GatsbyRedirect[]): Routi
             ReplaceKeyWith: withoutTrailingSlash(withoutLeadingSlash(route.toPath)),
             HttpRedirectCode: route.isPermanent ? '301' : '302',
             Protocol: pluginOptions.protocol,
-            HostName: pluginOptions.hostname,
+            HostName: pluginOptions.hostname
         }
-    })
-    )
-)
+    }))
+);
 
 let params: Params = {};
 


### PR DESCRIPTION
## Motivation

- **Don’t use public-read as a default anymore** (#41 et al), mostly because the AWS default is ‘private’.  
 However, ‘public-read’ is probably still the default people will likely want because there’s no other way to use most of `gatsby-plugin-s3`’s features without using the static website hosting functionality, which requires a public bucket policy to work correctly.  
 A ‘solution’ to this is making users explicitly specify what ACL they want (see changes to readme). If a ACL is not set, we will throw up a notice.
- **We won’t apply the ACL config setting to objects anymore.** - we’re gonna get rid of object ACL’s completely.  
 If users still explicitly wish to use this (deprecated) feature, they can manually do so by using the params field.
- **ACL’s will only be applied to bucket creation from now on.**  
 We could set the existing ACL to the config’s value, but I’m not sure if that’s behaviour we want.  
We don’t want private content to suddenly become public facing.

## Questions/Discussion

- Why even have ACL as a config field in the plugin if it only applies during creation?   
Maybe we should just drop bucket creation as a whole because it also involves additional required permissions…

## Roadmap

As mentioned in #41, this is breaking and will only be part of `1.0`.