### PR TITLE
Fixes S3 buckets with many existing objects causing the call-stack limit to be exceeded

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -65,20 +65,22 @@ const getParams = (path: string, params: Params): Partial<S3.Types.PutObjectRequ
     return returned;
 };
 
-const listAllObjects = async (s3: S3, bucketName: string, token?: NextToken): Promise<ObjectList> => {
+const listAllObjects = async (s3: S3, bucketName: string): Promise<ObjectList> => {
     const list: ObjectList = [];
-    const response = await s3.listObjectsV2({
-        Bucket: bucketName,
-        ContinuationToken: token
-    }).promise();
+    
+    let token: NextToken | undefined;
+    do {
+        const response = await s3.listObjectsV2({
+            Bucket: bucketName,
+            ContinuationToken: token
+        }).promise();
 
-    if (response.Contents) {
-        list.push(...response.Contents);
-    }
+        if (response.Contents) {
+            list.push(...response.Contents);
+        }
 
-    if (response.NextContinuationToken) {
-        list.push(...await listAllObjects(s3, bucketName, response.NextContinuationToken));
-    }
+        token = response.NextContinuationToken;
+    } while(token);
 
     return list;
 };


### PR DESCRIPTION
Fixes jariz/gatsby-plugin-s3#61

I just converted the recursion in listAllObjects into iteration.

If you want to test this, I highly recommend spinning up an EC2 instance (just a t3.micro will do) and performing all your tests there. On my local PC it took an hour before I reproduced the crash, on EC2 it took just a few minutes.

You can populate a bucket for testing like so:

```bash
mkdir files
cd files
dd if=/dev/urandom bs=1024 count=256 | split -a 5 -b 1 - file.
aws s3 sync . s3://manyfilestest.joshwalsh.me
```

This will create 262,144x1B files (enough to reproduce the issue) and upload them to an S3 bucket. Again, you should run this command on an EC2 instance.