### PR TITLE
Use objects with `x-amz-website-redirect-location` for permanent redirects

### DIFF
--- a/examples/with-redirects/gatsby-config.js
+++ b/examples/with-redirects/gatsby-config.js
@@ -9,7 +9,8 @@ module.exports = {
             resolve: `gatsby-plugin-s3`,
             options: {
                 bucketName: 'gatsby-plugin-s3-' + process.env.AWS_STAGE,
-                region: 'eu-west-1'
+                region: 'eu-west-1',
+                generateRedirectObjectsForPermanentRedirects: true
             },
         },
         {

--- a/examples/with-redirects/gatsby-node.js
+++ b/examples/with-redirects/gatsby-node.js
@@ -16,4 +16,16 @@ exports.createPages = ({ actions }) => {
         toPath: '/client-only',
         isPermanent: false
     });
+
+    actions.createRedirect({
+        fromPath: '/asdf123.-~_!$&\'()*+,;=:@%',
+        toPath: '/special-characters',
+        isPermanent: true
+    });
+
+    actions.createRedirect({
+        fromPath: '/trailing-slash/',
+        toPath: '/trailing-slash/1',
+        isPermanent: true
+    });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-plugin-s3",
-    "version": "0.2.4",
+    "version": "0.2.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -783,19 +783,25 @@
             }
         },
         "@babel/polyfill": {
-            "version": "7.2.5",
-            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-            "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+            "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
             "dev": true,
             "requires": {
-                "core-js": "^2.5.7",
-                "regenerator-runtime": "^0.12.0"
+                "core-js": "^2.6.5",
+                "regenerator-runtime": "^0.13.2"
             },
             "dependencies": {
+                "core-js": {
+                    "version": "2.6.5",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+                    "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+                    "dev": true
+                },
                 "regenerator-runtime": {
-                    "version": "0.12.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "version": "0.13.2",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+                    "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
                     "dev": true
                 }
             }
@@ -2287,6 +2293,7 @@
             "version": "23.6.0",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
             "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+            "dev": true,
             "requires": {
                 "babel-plugin-istanbul": "^4.1.6",
                 "babel-preset-jest": "^23.2.0"
@@ -2350,7 +2357,8 @@
         "babel-plugin-jest-hoist": {
             "version": "23.2.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-            "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
+            "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
+            "dev": true
         },
         "babel-plugin-macros": {
             "version": "2.4.3",
@@ -2716,6 +2724,7 @@
             "version": "23.2.0",
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
             "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+            "dev": true,
             "requires": {
                 "babel-plugin-jest-hoist": "^23.2.0",
                 "babel-plugin-syntax-object-rest-spread": "^6.13.0"
@@ -3262,14 +3271,6 @@
             "requires": {
                 "caniuse-lite": "^1.0.30000844",
                 "electron-to-chromium": "^1.3.47"
-            }
-        },
-        "bs-logger": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-            "requires": {
-                "fast-json-stable-stringify": "2.x"
             }
         },
         "bser": {
@@ -9118,6 +9119,29 @@
                         "source-map": "^0.5.7"
                     }
                 },
+                "babel-jest": {
+                    "version": "23.6.0",
+                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+                    "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+                    "requires": {
+                        "babel-plugin-istanbul": "^4.1.6",
+                        "babel-preset-jest": "^23.2.0"
+                    }
+                },
+                "babel-plugin-jest-hoist": {
+                    "version": "23.2.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+                    "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
+                },
+                "babel-preset-jest": {
+                    "version": "23.2.0",
+                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+                    "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+                    "requires": {
+                        "babel-plugin-jest-hoist": "^23.2.0",
+                        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+                    }
+                },
                 "babylon": {
                     "version": "6.18.0",
                     "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
@@ -9951,6 +9975,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
             "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.0"
             }
@@ -10336,11 +10361,6 @@
             "requires": {
                 "pify": "^3.0.0"
             }
-        },
-        "make-error": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
         },
         "makeerror": {
             "version": "1.0.11",
@@ -13824,6 +13844,7 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
             "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+            "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
             }
@@ -15708,32 +15729,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-        },
-        "ts-jest": {
-            "version": "23.10.5",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.5.tgz",
-            "integrity": "sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==",
-            "requires": {
-                "bs-logger": "0.x",
-                "buffer-from": "1.x",
-                "fast-json-stable-stringify": "2.x",
-                "json5": "2.x",
-                "make-error": "1.x",
-                "mkdirp": "0.x",
-                "resolve": "1.x",
-                "semver": "^5.5",
-                "yargs-parser": "10.x"
-            },
-            "dependencies": {
-                "yargs-parser": {
-                    "version": "10.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-                    "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-                    "requires": {
-                        "camelcase": "^4.1.0"
-                    }
-                }
-            }
         },
         "tslib": {
             "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {
         "@babel/cli": "^7.2.3",
         "@babel/core": "^7.2.2",
+        "@babel/polyfill": "^7.4.4",
         "@babel/preset-env": "^7.2.3",
         "@babel/preset-typescript": "^7.1.0",
         "@types/es6-promisify": "^6.0.0",
@@ -38,6 +39,7 @@
         "@types/ora": "^3.0.0",
         "@types/stream-to-promise": "^2.2.0",
         "@types/yargs": "^12.0.2",
+        "babel-jest": "^23.6.0",
         "es6-promisify": "^6.0.1",
         "gatsby": "^2.0.72",
         "glob": "^7.1.3",
@@ -78,6 +80,23 @@
         "testPathIgnorePatterns": [
             "/node_modules/",
             "/.cache/"
+        ],
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js",
+            "json",
+            "jsx",
+            "node"
+        ],
+        "testMatch": [
+            "**/?(*.)+(spec|test).ts"
+        ],
+        "transform": {
+            "^.+\\.tsx?$": "babel-jest"
+        },
+        "setupFiles": [
+            "@babel/polyfill"
         ]
     }
 }

--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -13,7 +13,7 @@ if (!TESTING_ENDPOINT) {
 
 console.debug(chalk`{blue.bold INFO} using {bold ${TESTING_ENDPOINT}} as endpoint to test against.`);
 
-const PUBLIC_DIR = path.join(__dirname, 'examples', 'with-redirects', 'public');
+const PUBLIC_DIR = path.join(__dirname, '..', 'examples', 'with-redirects', 'public');
 
 describe('applies caching and content type headers', () => {
     for (const pattern of Object.keys(CACHING_PARAMS)) {

--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -68,5 +68,17 @@ describe('redirects', () => {
         const followedRedirect = await fetch(response.headers.get('location')!);
         expect(followedRedirect.status).toBe(200);
     });
+
+    test('special characters using WebsiteRedirectLocation', async () => {
+        const response = await fetch(TESTING_ENDPOINT + '/asdf123.-~_!%24%26\'()*%2B%2C%3B%3D%3A%40%25', { redirect: 'manual' });
+        expect(response.status).toBe(301);
+        expect(response.headers.get('location')).toBe(TESTING_ENDPOINT + '/special-characters');
+    });
+
+    test('trailing slash using WebsiteRedirectLocation', async () => {
+        const response = await fetch(TESTING_ENDPOINT + '/trailing-slash/', { redirect: 'manual' });
+        expect(response.status).toBe(301);
+        expect(response.headers.get('location')).toBe(TESTING_ENDPOINT + '/trailing-slash/1');
+    });
 });
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -109,7 +109,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
         const config: PluginOptions = await readJson(CACHE_FILES.config);
         const params: Params = await readJson(CACHE_FILES.params);
         const routingRules: RoutingRules = await readJson(CACHE_FILES.routingRules);
-        const redirectObjects: GatsbyRedirect[] = fs.existsSync(CACHE_FILES.redirectObjects) ? await readJson(CACHE_FILES.redirectObjects) : []
+        const redirectObjects: GatsbyRedirect[] = fs.existsSync(CACHE_FILES.redirectObjects) ? await readJson(CACHE_FILES.redirectObjects) : [];
 
         // Override the bucket name if it is set via command line
         if (bucket) {
@@ -240,11 +240,11 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
 
         uploadQueue.push(...redirectObjects.map(redirect =>
             asyncify(async () => {
-                const { fromPath, toPath: redirectLocation } = redirect
+                const { fromPath, toPath: redirectLocation } = redirect;
 
-                let key = withoutLeadingSlash(fromPath)
+                let key = withoutLeadingSlash(fromPath);
                 if (/\/$/.test(key)) {
-                    key = join(key, 'index.html')
+                    key = join(key, 'index.html');
                 }
 
                 const tag = `"${createHash('md5').update(redirectLocation).digest('hex')}"`;
@@ -269,7 +269,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
                             WebsiteRedirectLocation: redirectLocation,
                             ...getParams(key, params)
                         }
-                    })
+                    });
 
                     await upload.promise();
             

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -20,7 +20,7 @@ import inquirer from 'inquirer';
 import { config } from 'aws-sdk';
 import { createHash } from 'crypto';
 import isCI from 'is-ci';
-import { withoutLeadingSlash, withoutTrailingSlash } from './util';
+import { withoutLeadingSlash } from './util';
 
 const cli = yargs();
 const pe = new PrettyError();
@@ -223,13 +223,13 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
         });
 
         promises.push(...permanentRedirects.map(async redirect => {
-            const { fromPath, toPath } = redirect
+            const { fromPath, toPath: redirectLocation } = redirect
 
             let key = withoutLeadingSlash(fromPath)
             if (/\/$/.test(key)) {
                 key = join(key, 'index.html')
             }
-            const redirectLocation = '/' + withoutTrailingSlash(withoutLeadingSlash(toPath))
+
             const tag = `"${createHash('md5').update(redirectLocation).digest('hex')}"`;
             const object = objects.find(object => object.Key === key && object.ETag === tag);
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -12,7 +12,7 @@ import streamToPromise from 'stream-to-promise';
 import ora from 'ora';
 import chalk from 'chalk';
 import { Readable } from 'stream';
-import { relative, resolve, sep } from 'path';
+import { relative, resolve, sep, join } from 'path';
 import fs from 'fs';
 import minimatch from 'minimatch';
 import mime from 'mime';
@@ -225,7 +225,10 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
         promises.push(...permanentRedirects.map(async redirect => {
             const { fromPath, toPath } = redirect
 
-            const key = withoutLeadingSlash(fromPath)
+            let key = withoutLeadingSlash(fromPath)
+            if (/\/$/.test(key)) {
+                key = join(key, 'index.html')
+            }
             const redirectLocation = '/' + withoutTrailingSlash(withoutLeadingSlash(toPath))
             const tag = `"${createHash('md5').update(redirectLocation).digest('hex')}"`;
             const object = objects.find(object => object.Key === key && object.ETag === tag);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -243,7 +243,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
                     params: {
                         Bucket: config.bucketName,
                         Key: key,
-                        Body: toPath,
+                        Body: redirectLocation,
                         ACL: config.acl === null ? undefined : (config.acl || 'public-read'),
                         ContentType: 'application/octet-stream',
                         WebsiteRedirectLocation: redirectLocation,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -109,7 +109,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
         const config: PluginOptions = await readJson(CACHE_FILES.config);
         const params: Params = await readJson(CACHE_FILES.params);
         const routingRules: RoutingRules = await readJson(CACHE_FILES.routingRules);
-        const permanentRedirects: GatsbyRedirect[] = await readJson(CACHE_FILES.permanentRedirects)
+        const redirectObjects: GatsbyRedirect[] = fs.existsSync(CACHE_FILES.redirectObjects) ? await readJson(CACHE_FILES.redirectObjects) : []
 
         // Override the bucket name if it is set via command line
         if (bucket) {
@@ -238,7 +238,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
             }));
         });
 
-        uploadQueue.push(...permanentRedirects.map(redirect =>
+        uploadQueue.push(...redirectObjects.map(redirect =>
             asyncify(async () => {
                 const { fromPath, toPath: redirectLocation } = redirect
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -222,10 +222,8 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
             }
         });
 
-        fs.appendFileSync('tmp/deploy.log', `redirect count: ${permanentRedirects.length}\n`)
         promises.push(...permanentRedirects.map(async redirect => {
             const { fromPath, toPath } = redirect
-            fs.appendFileSync('tmp/deploy.log', `redirect ${fromPath} => ${toPath}\n`)
 
             const key = withoutLeadingSlash(fromPath)
             const redirectLocation = '/' + withoutTrailingSlash(withoutLeadingSlash(toPath))
@@ -240,7 +238,6 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
             }
 
             try {
-                fs.appendFileSync('tmp/deploy.log', `create managed upload for ${key} => ${redirectLocation}\n`)
                 const promise = new S3.ManagedUpload({
                     service: s3,
                     params: {
@@ -255,7 +252,6 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
                 }).promise();
                 promises.push(promise);
                 await promise;
-                fs.appendFileSync('tmp/deploy.log', `uploaded ${key} => ${redirectLocation}`)
                 spinner.text = chalk`Syncing...\n{dim   Created Redirect {cyan ${key}} => {cyan ${redirectLocation}}}\n`;
             } catch (ex) {
                 spinner.fail(chalk`Upload failure for object {cyan ${key}}`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,12 @@ export interface PluginOptions {
     // The plugin will generate routing rules to be applied to the website config for all redirects it can find
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html
     generateRoutingRules?: boolean,
+
+    // The plugin will not generate routing rules for permanent (301) redirects, but will instead upload empty objects
+    // with the `x-amz-website-redirect-location` property.  This can be used to get around the hard limit of 50
+    // routing rules on AWS S3.
+    // https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html
+    generateRedirectObjectsForPermanentRedirects?: boolean
     
     // The plugin will create a fake index page if a redirect from the root path is made - as a workaround, 
     // Because routing rules can't be applied in that situation
@@ -68,6 +74,8 @@ export const DEFAULT_OPTIONS: PluginOptions = {
     params: {},
     mergeCachingParams: true,
     generateRoutingRules: true,
+    // TODO: set this to true by default in the next major version
+    generateRedirectObjectsForPermanentRedirects: false,
     generateIndexPageForRedirect: true,
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const CACHE_FILES = {
     config: path.join('.cache', 's3.config.json'),
     params: path.join('.cache', 's3.params.json'),
     routingRules: path.join('.cache', 's3.routingRules.json'),
+    permanentRedirects: path.join('.cache', 's3.permanentRedirects.json')
 };
 
 export type Params = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const CACHE_FILES = {
     config: path.join('.cache', 's3.config.json'),
     params: path.join('.cache', 's3.params.json'),
     routingRules: path.join('.cache', 's3.routingRules.json'),
-    permanentRedirects: path.join('.cache', 's3.permanentRedirects.json')
+    redirectObjects: path.join('.cache', 's3.redirectObjects.json')
 };
 
 export type Params = {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -132,7 +132,6 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
         ];
         if (!pluginOptions.generateRedirectObjectsForPermanentRedirects) {
             routingRules.push(...getRules(pluginOptions, permanentRedirects))
-            permanentRedirects = []
         }
         if (routingRules.length > 50) {
             throw new Error(`${routingRules.length} routing rules provided, the number of routing rules in a website configuration is limited to 50.\n` +
@@ -155,10 +154,12 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
         JSON.stringify(slsRoutingRules)
     );
 
-    fs.writeFileSync(
-        path.join(program.directory, './.cache/s3.permanentRedirects.json'),
-        JSON.stringify(permanentRedirects)
-    )
+    if (pluginOptions.generateRedirectObjectsForPermanentRedirects) {
+        fs.writeFileSync(
+            path.join(program.directory, './.cache/s3.redirectObjects.json'),
+            JSON.stringify(permanentRedirects)
+        )
+    }
 
     fs.writeFileSync(
         path.join(program.directory, './.cache/s3.params.json'),

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { RoutingRule, RoutingRules } from 'aws-sdk/clients/s3';
 import { withoutLeadingSlash, withoutTrailingSlash } from './util';
+import { resolve } from 'url';
 
 // for whatever reason, the keys of the RoutingRules object in the SDK and the actual API differ.
 // so we have a separate object with those differing keys which we can throw into the sls config.
@@ -108,8 +109,6 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
 
     const temporaryRedirects = redirects.filter(redirect => redirect.fromPath !== '/')
         .filter(redirect => !redirect.isPermanent)
-    const permanentRedirects = redirects.filter(redirect => redirect.fromPath !== '/')
-        .filter(redirect => redirect.isPermanent)
 
     if (pluginOptions.generateRoutingRules) {
         routingRules = [
@@ -124,6 +123,21 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
             RoutingRuleCondition: Condition,
             RedirectRule: Redirect
         }));
+    }
+
+    let permanentRedirects: GatsbyRedirect[] = redirects.filter(redirect => redirect.fromPath !== '/')
+        .filter(redirect => redirect.isPermanent)
+
+    if (pluginOptions.hostname && pluginOptions.protocol) {
+        const base = `${pluginOptions.protocol}://${pluginOptions.hostname}`
+        permanentRedirects = permanentRedirects.map((redirect) => {
+            return {
+                ...redirect,
+                toPath: resolve(base, redirect.toPath)
+            }
+        })
+    } else if(pluginOptions.hostname || pluginOptions.protocol) {
+        throw new Error(`Please either provide both 'hostname' and 'protocol', or neither of them.`)
     }
 
     fs.writeFileSync(

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -108,21 +108,21 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
     let slsRoutingRules: ServerlessRoutingRule[] = [];
 
     const temporaryRedirects = redirects.filter(redirect => redirect.fromPath !== '/')
-        .filter(redirect => !redirect.isPermanent)
+        .filter(redirect => !redirect.isPermanent);
     
     let permanentRedirects: GatsbyRedirect[] = redirects.filter(redirect => redirect.fromPath !== '/')
-        .filter(redirect => redirect.isPermanent)
+        .filter(redirect => redirect.isPermanent);
 
     if (pluginOptions.hostname && pluginOptions.protocol) {
-        const base = `${pluginOptions.protocol}://${pluginOptions.hostname}`
+        const base = `${pluginOptions.protocol}://${pluginOptions.hostname}`;
         permanentRedirects = permanentRedirects.map((redirect) => {
             return {
                 ...redirect,
                 toPath: resolve(base, redirect.toPath)
             }
-        })
+        });
     } else if(pluginOptions.hostname || pluginOptions.protocol) {
-        throw new Error(`Please either provide both 'hostname' and 'protocol', or neither of them.`)
+        throw new Error(`Please either provide both 'hostname' and 'protocol', or neither of them.`);
     }
 
     if (pluginOptions.generateRoutingRules) {
@@ -131,11 +131,11 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
             ...getRules(pluginOptions, rewrites)
         ];
         if (!pluginOptions.generateRedirectObjectsForPermanentRedirects) {
-            routingRules.push(...getRules(pluginOptions, permanentRedirects))
+            routingRules.push(...getRules(pluginOptions, permanentRedirects));
         }
         if (routingRules.length > 50) {
             throw new Error(`${routingRules.length} routing rules provided, the number of routing rules in a website configuration is limited to 50.\n` +
-                `  Try setting the 'generateRedirectObjectsForPermanentRedirects' configuration option.`)
+                `  Try setting the 'generateRedirectObjectsForPermanentRedirects' configuration option.`);
         }
         
         slsRoutingRules = routingRules.map(({ Redirect, Condition }) => ({
@@ -158,7 +158,7 @@ export const onPostBuild = ({ store }: any, userPluginOptions: PluginOptions) =>
         fs.writeFileSync(
             path.join(program.directory, './.cache/s3.redirectObjects.json'),
             JSON.stringify(permanentRedirects)
-        )
+        );
     }
 
     fs.writeFileSync(


### PR DESCRIPTION
We ran into an issue where we want more than 50 redirects in our s3 bucket, and there's a hard limit in s3 on the number of routing rules you can set on a bucket.  An alternative is to use the `x-amz-website-redirect-location` header on an object.  I propose doing that by default for all 301 redirects.

documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html

Happy to add a configuration flag to toggle this behavior off if you'd like.