### PR TITLE
Made S3 bucket hosting optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Default configuration is as follows:
     generateIndexPageForRedirect: true,
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
-    customAwsEndpointHostname: undefined
+    customAwsEndpointHostname: undefined,
+    hostSiteFromS3: true
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Default configuration is as follows:
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
     customAwsEndpointHostname: undefined,
-    hostSiteFromS3: true
+    disableS3StaticWebsiteHosting: false
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Default configuration is as follows:
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
     customAwsEndpointHostname: undefined,
-    disableS3StaticWebsiteHosting: false
+    enableS3StaticWebsiteHosting: true
 };
 ```
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -164,7 +164,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
             await s3.createBucket(params).promise();
         }
 
-        if(config.hostSiteFromS3) {
+        if(!config.disableS3StaticWebsiteHosting) {
             const websiteConfig: S3.Types.PutBucketWebsiteRequest = {
                 Bucket: config.bucketName,
                 WebsiteConfiguration: {
@@ -305,7 +305,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
         }
 
         spinner.succeed('Synced.');
-        if(config.hostSiteFromS3) {
+        if(!config.disableS3StaticWebsiteHosting) {
             const s3WebsiteDomain = getS3WebsiteDomainUrl(region || 'us-east-1');
             console.log(chalk`
             {bold Your website is online at:}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -164,7 +164,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
             await s3.createBucket(params).promise();
         }
 
-        if(!config.disableS3StaticWebsiteHosting) {
+        if(config.enableS3StaticWebsiteHosting) {
             const websiteConfig: S3.Types.PutBucketWebsiteRequest = {
                 Bucket: config.bucketName,
                 WebsiteConfiguration: {
@@ -305,7 +305,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
         }
 
         spinner.succeed('Synced.');
-        if(!config.disableS3StaticWebsiteHosting) {
+        if(config.enableS3StaticWebsiteHosting) {
             const s3WebsiteDomain = getS3WebsiteDomainUrl(region || 'us-east-1');
             console.log(chalk`
             {bold Your website is online at:}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,7 @@ export interface PluginOptions {
     customAwsEndpointHostname?: string,
 
     // Override S3 website bucket hosting, for example when used with Cloudfront
-    hostSiteFromS3?: boolean
+    disableS3StaticWebsiteHosting?: boolean
 } 
 
 export const DEFAULT_OPTIONS: PluginOptions = {
@@ -82,7 +82,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
     generateIndexPageForRedirect: true,
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
-    hostSiteFromS3: true,
+    disableS3StaticWebsiteHosting: true,
 };
 
 export const CACHING_PARAMS: Params = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,7 +65,10 @@ export interface PluginOptions {
     removeNonexistentObjects?: boolean,
     
     // Custom AWS S3 endpoint, default Amazon AWS hostname  - amazonaws.com
-    customAwsEndpointHostname?: string
+    customAwsEndpointHostname?: string,
+
+    // Override S3 website bucket hosting, for example when used with Cloudfront
+    hostSiteFromS3?: boolean
 } 
 
 export const DEFAULT_OPTIONS: PluginOptions = {
@@ -79,6 +82,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
     generateIndexPageForRedirect: true,
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
+    hostSiteFromS3: true,
 };
 
 export const CACHING_PARAMS: Params = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,8 +67,11 @@ export interface PluginOptions {
     // Custom AWS S3 endpoint, default Amazon AWS hostname  - amazonaws.com
     customAwsEndpointHostname?: string,
 
-    // Override S3 website bucket hosting, for example when used with Cloudfront
-    disableS3StaticWebsiteHosting?: boolean
+    // Disables modifications to the S3 Static Website Hosting configuration. Without S3 Static Website Hosting some features
+    // (index.html rewriting, trailing slash redirects, and serverside redirects) will not function. Not recommended,
+    // but could be useful for preventing Cloud formation Stack Drift or suppressing Terraform noise if you don't need
+    // the static website hosting functionality.
+    enableS3StaticWebsiteHosting?: boolean
 } 
 
 export const DEFAULT_OPTIONS: PluginOptions = {
@@ -82,7 +85,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
     generateIndexPageForRedirect: true,
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
-    disableS3StaticWebsiteHosting: true,
+    enableS3StaticWebsiteHosting: true,
 };
 
 export const CACHING_PARAMS: Params = {


### PR DESCRIPTION
When using CloudFront, S3 hosting is not needed (we use an edge lambda to append `/index.html` to any requests for directories.  This change allows S3 bucket hosting to be disabled if preferred, whilst maintaining the plugin's default behaviour.

Full disclosure, this is my first time working with typescript, but I built the plugin locally and tried it in my project, and it appears to work as I expected.