### PR TITLE
Fix entire URL being concatenated into the redirect key when generateRedirectObjectsForPermanentRedirects is disabled

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -13,6 +13,7 @@ import ora from 'ora';
 import chalk from 'chalk';
 import { Readable } from 'stream';
 import { join, relative, resolve, sep } from 'path';
+import { resolve as resolveUrl } from 'url';
 import fs from 'fs';
 import util from 'util';
 import minimatch from 'minimatch';
@@ -245,9 +246,11 @@ const deploy = async ({ yes, bucket }: { yes: boolean, bucket: string }) => {
             }));
         });
 
+        const base = (config.protocol && config.hostname) ? `${config.protocol}://${config.hostname}` : null;
         uploadQueue.push(...redirectObjects.map(redirect =>
             asyncify(async () => {
-                const { fromPath, toPath: redirectLocation } = redirect;
+                const { fromPath, toPath: redirectPath } = redirect;
+                const redirectLocation = base ? resolveUrl(base, redirectPath) : redirectPath;
 
                 let key = withoutLeadingSlash(fromPath);
                 if (/\/$/.test(key)) {


### PR DESCRIPTION
Fixes #81

Concatenation of protocol and hostname is only necessary for redirect objects. Applying it to redirect rules causes the created redirect to have an incorrect target.


We might want to look at a more sophisticated test suite (that allows us to deploy multiple times with different configs) but in the meantime I have performed the following manually:
 - Running integration test with old code and generateRedirectObjectsForPermanentRedirects set to false. Reproduced invalid redirect issue.
 - Running integration test with new code and generateRedirectObjectsForPermanentRedirects set to false. Issue is resolved, correct redirect was created.
 - Running integration test with new code and generateRedirectObjectsForPermanentRedirects set to true. Correct redirect was created.