### PR TITLE
Add config option `bucketPrefix` for CloudFront origin path

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,7 +103,7 @@ export const CACHING_PARAMS: Params = {
     'page-data/**/**.json': {
         CacheControl: 'public, max-age=0, must-revalidate',
     },
-    'static/**': {
+    '**/static/**': {
         CacheControl: 'public, max-age=31536000, immutable',
     },
     '**/**/!(sw).js': {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,10 @@ export interface PluginOptions {
     // Your bucket name (required)
     bucketName: string;
 
+    // An optional prefix/directory to use on the bucket. This requires the bucket to already be
+    // created. Do not include leading or trailing slashes. Can be useful with CloudFront originPath option.
+    bucketPrefix?: string;
+
     // Your region
     // If not specified: will default to whatever the AWS SDK decides is the default otherwise
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-environment-variable


### PR DESCRIPTION
This is related to #24 

Specifically, this adds support for an optional `bucketPrefix` option to be used for uploading the build into a directory in the S3 bucket. This is different than `pathPrefix` which is related to the actual build content and linking of pages therein.

In practical terms, this would relate to the directory path/origin path option in CloudFront.

More info here: https://aws.amazon.com/about-aws/whats-new/2014/12/16/amazon-cloudfront-now-allows-directory-path-as-origin-name/