### PR TITLE
Cache settings on page-data directory

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,21 +16,21 @@ export type Params = {
 export interface PluginOptions {
     // Your bucket name (required)
     bucketName: string;
-    
+
     // Your region
     // If not specified: will default to whatever the AWS SDK decides is the default otherwise
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-environment-variable
     region?: string;
 
     // The protocol & hostname of your site
-    // If you are using a CDN or reverse-proxy (such as CloudFront) in front of S3 
+    // If you are using a CDN or reverse-proxy (such as CloudFront) in front of S3
     // then you must fill out these fields to ensure redirects work correctly
     // If you are just using your S3 website directly, this is unnecessary
     protocol?: 'http' | 'https';
     hostname?: string;
-    
+
     // Custom params to apply to your files
-    // see all available params here: 
+    // see all available params here:
     // https://github.com/aws/aws-sdk-js/blob/83ebfbcc6ab30b9a486b15cdede26a1bd03c72e4/clients/s3.d.ts#L3573
     // @example:
     // { '/static/**': {
@@ -54,32 +54,32 @@ export interface PluginOptions {
     // routing rules on AWS S3.
     // https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html
     generateRedirectObjectsForPermanentRedirects?: boolean;
-    
-    // The plugin will create a fake index page if a redirect from the root path is made - as a workaround, 
+
+    // The plugin will create a fake index page if a redirect from the root path is made - as a workaround,
     // Because routing rules can't be applied in that situation
     generateIndexPageForRedirect?: boolean;
-    
+
     // Generate rewrites for client only paths
     generateMatchPathRewrites?: boolean;
 
     // Remove S3 objects if they no longer exist locally
     removeNonexistentObjects?: boolean;
-    
+
     // Custom AWS S3 endpoint, default Amazon AWS hostname  - amazonaws.com
     customAwsEndpointHostname?: string;
 
-    // Disables modifications to the S3 Static Website Hosting configuration. 
-    // Without S3 Static Website Hosting some features 
-    // (index.html rewriting, trailing slash redirects, and serverside redirects) 
+    // Disables modifications to the S3 Static Website Hosting configuration.
+    // Without S3 Static Website Hosting some features
+    // (index.html rewriting, trailing slash redirects, and serverside redirects)
     // will not function. Not recommended,
     // but could be useful for preventing Cloud formation Stack Drift or suppressing Terraform noise if you don't need
     // the static website hosting functionality.
     enableS3StaticWebsiteHosting?: boolean;
-} 
+}
 
 export const DEFAULT_OPTIONS: PluginOptions = {
     bucketName: '',
-    
+
     params: {},
     mergeCachingParams: true,
     generateRoutingRules: true,
@@ -91,8 +91,12 @@ export const DEFAULT_OPTIONS: PluginOptions = {
     enableS3StaticWebsiteHosting: true,
 };
 
+// https://www.gatsbyjs.org/docs/caching/
 export const CACHING_PARAMS: Params = {
     '**/**.html': {
+        CacheControl: 'public, max-age=0, must-revalidate',
+    },
+    'page-data/**/**.json': {
         CacheControl: 'public, max-age=0, must-revalidate',
     },
     'static/**': {


### PR DESCRIPTION
The cache settings are not set for JSON files in the page-data directory as mentioned here:
https://www.gatsbyjs.org/docs/caching/

This fix means that old page-data files will not be returned, thus avoiding errors where new data is unavailable or old data is returned.