### PR TITLE
Add parallel limit to config

### DIFF
--- a/docs/.awesome/content/index.md
+++ b/docs/.awesome/content/index.md
@@ -91,7 +91,8 @@ Default configuration is as follows:
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
     customAwsEndpointHostname: undefined,
-    enableS3StaticWebsiteHosting: true
+    enableS3StaticWebsiteHosting: true,
+    parallelLimit: 20,
 };
 ```
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -315,7 +315,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean; bucket: string }) => {
         );
 
         await streamToPromise(stream as Readable);
-        await promisifiedParallelLimit(uploadQueue, 20);
+        await promisifiedParallelLimit(uploadQueue, config.parallelLimit ? config.parallelLimit : 20);
 
         if (config.removeNonexistentObjects) {
             const objectsToRemove = objects

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -315,7 +315,7 @@ const deploy = async ({ yes, bucket }: { yes: boolean; bucket: string }) => {
         );
 
         await streamToPromise(stream as Readable);
-        await promisifiedParallelLimit(uploadQueue, config.parallelLimit ? config.parallelLimit : 20);
+        await promisifiedParallelLimit(uploadQueue, config.parallelLimit as number);
 
         if (config.removeNonexistentObjects) {
             const objectsToRemove = objects

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,6 +101,7 @@ export const DEFAULT_OPTIONS: S3PluginOptions = {
     generateMatchPathRewrites: true,
     removeNonexistentObjects: true,
     enableS3StaticWebsiteHosting: true,
+    parallelLimit: 20,
 
     // the typing requires this for some reason...
     plugins: [],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,7 +86,6 @@ export interface S3PluginOptions extends PluginOptions {
     enableS3StaticWebsiteHosting?: boolean;
 
     // Max number of files to upload in parallel.
-    // This value should not exceed the maximum number of open files supported by the system.
     parallelLimit?: number;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -84,6 +84,10 @@ export interface S3PluginOptions extends PluginOptions {
     // but could be useful for preventing Cloud formation Stack Drift or suppressing Terraform noise if you don't need
     // the static website hosting functionality.
     enableS3StaticWebsiteHosting?: boolean;
+
+    // Max number of files to upload in parallel.
+    // This value should not exceed the maximum number of open files supported by the system.
+    parallelLimit?: number;
 }
 
 export const DEFAULT_OPTIONS: S3PluginOptions = {


### PR DESCRIPTION
We use this plugin to upload a Gatsby build with a large number of static pages and the hard coded limit of 20 slows down our deployment process significantly. This change adds the ability to set a custom parallel upload limit. 