### PR TITLE
Improve deploy performance by using a hashmap of key->tag instead of array find

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -210,7 +210,7 @@ const deploy = async ({ yes, bucket, userAgent }: { yes: boolean; bucket: string
         spinner.text = 'Listing objects...';
         spinner.color = 'green';
         const objects = await listAllObjects(s3, config.bucketName, config.bucketPrefix);
-        const keyTagMapObjects = objects.reduce((acc: any, curr) => {
+        const keyToETagMap = objects.reduce((acc: any, curr) => {
             acc[curr.Key!] = curr.ETag;
             return acc;
         }, {});
@@ -236,7 +236,7 @@ const deploy = async ({ yes, bucket, userAgent }: { yes: boolean; bucket: string
                     const data = await streamToPromise(hashStream);
 
                     const tag = `"${data}"`;
-                    const objectUnchanged = keyTagMapObjects[key] === tag;
+                    const objectUnchanged = keyToETagMap[key] === tag;
 
                     isKeyInUse[key] = true;
 
@@ -289,7 +289,7 @@ const deploy = async ({ yes, bucket, userAgent }: { yes: boolean; bucket: string
                     const tag = `"${createHash('md5')
                         .update(redirectLocation)
                         .digest('hex')}"`;
-                    const objectUnchanged = keyTagMapObjects[key] === tag;
+                    const objectUnchanged = keyToETagMap[key] === tag;
 
                     isKeyInUse[key] = true;
 


### PR DESCRIPTION
Your idea in #152 was correct. 
I tested this in a bucket with 12k objects. Got deployment from 10 seconds to 1-2

Also tested in a bucket with 180k items and got deployment down from 20m to 3m.  From the 3m also around 50 seconds are for fetching all the objects from S3. Potentially this hashmap could be kept in a single file and just fetch that one.

Also my numbers are not exact just because i was keeping track of this in circleci since i wanted to test in a real deploy environment than my pc. 