### PR TITLE
Generate .d.ts type definition files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ jspm_packages/
 .idea/
 /*.js
 /*.js.map
+/*.d.ts
 docs/build/
 
 /test/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gatsby-plugin-s3",
     "version": "0.3.5",
     "description": "Enables you to deploy your gatsby site to a S3 bucket.",
-    "main": "bin.js",
+    "main": "index.js",
     "bin": "bin.js",
     "scripts": {
         "test": "jest",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -106,7 +106,12 @@ const createSafeS3Key = (key: string): string => {
     return key;
 };
 
-const deploy = async ({ yes, bucket, userAgent }: { yes: boolean; bucket: string; userAgent: string }) => {
+export interface DeployArguments {
+    yes?: boolean;
+    bucket?: string;
+    userAgent?: string;
+}
+export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) => {
     const spinner = ora({ text: 'Retrieving bucket info...', color: 'magenta', stream: process.stdout }).start();
     let dontPrompt = yes;
 
@@ -135,7 +140,7 @@ const deploy = async ({ yes, bucket, userAgent }: { yes: boolean; bucket: string
         const s3 = new S3({
             region: config.region,
             endpoint: config.customAwsEndpointHostname,
-            customUserAgent: userAgent || '',
+            customUserAgent: userAgent ?? '',
             httpOptions,
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { deploy, DeployArguments } from './bin';
+export { S3PluginOptions } from './constants';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "resolveJsonModule": true,
-        "baseUrl": "./src"
+        "baseUrl": "./src",
+        "declaration": true
     },
     "include": [
         "./src",


### PR DESCRIPTION
Fixes #190

I've done the bare minimum to make this usable. You can import the types like this:

```typescript
import {S3PluginOptions as GatsbyPluginS3Options} from 'gatsby-plugin-s3/constants';

const test: GatsbyPluginS3Options = {};
```

Do we want to export the types from an index file so that they can be imported from `gatsby-plugin-s3`? Importing `gatsby-plugin-s3/constants` isn't very intuitive.