### PR TITLE
fix: CacheControl header is not set correctly when bucketPrefix is set

### DIFF
--- a/examples/with-redirects/gatsby-config.js
+++ b/examples/with-redirects/gatsby-config.js
@@ -12,6 +12,7 @@ module.exports = {
             resolve: `gatsby-plugin-s3`,
             options: {
                 bucketName: process.env.GATSBY_S3_TARGET_BUCKET || 'test',
+                bucketPrefix: process.env.GATSBY_S3_BUCKET_PREFIX ? process.env.GATSBY_S3_BUCKET_PREFIX : null,
                 region: 'eu-west-1',
                 generateRedirectObjectsForPermanentRedirects: !process.env.GATSBY_S3_LEGACY_REDIRECTS,
                 ...(process.env.GATSBY_S3_ACL

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -2,7 +2,7 @@ import { CACHING_PARAMS, DEFAULT_OPTIONS, GatsbyRedirect, GatsbyState, Params, S
 import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';
-import { Condition, Redirect, RoutingRule, RoutingRules } from 'aws-sdk/clients/s3';
+import { Condition, Redirect, RoutingRule, RoutingRules, Types } from 'aws-sdk/clients/s3';
 import { withoutLeadingSlash, withoutTrailingSlash } from './util';
 import { GatsbyNode, Page } from 'gatsby';
 
@@ -118,9 +118,19 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = ({ store }, userPluginOpti
     }
 
     if (pluginOptions.mergeCachingParams) {
+        const prefixedCachingParams = Object.entries(CACHING_PARAMS)
+            .map(
+                ([key, val]) =>
+                    [pluginOptions.bucketPrefix ? `${pluginOptions.bucketPrefix}/${key}` : key, val] as [
+                        string,
+                        Partial<Types.PutObjectRequest>
+                    ]
+            )
+            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+
         params = {
             ...params,
-            ...CACHING_PARAMS,
+            ...prefixedCachingParams,
         };
     }
 

--- a/src/test/e2e.test.ts
+++ b/src/test/e2e.test.ts
@@ -317,3 +317,51 @@ describe('rules-based redirects', () => {
         });
     });
 });
+
+describe('with pathPrefix', () => {
+    beforeAll(async () => {
+        await buildSite('with-redirects', {
+            GATSBY_S3_TARGET_BUCKET: bucketName,
+            GATSBY_S3_BUCKET_PREFIX: 'prefixed',
+            GATSBY_S3_LEGACY_REDIRECTS: EnvironmentBoolean.True,
+        });
+        await deploySite('with-redirects', [
+            Permission.CreateBucket,
+            Permission.PutObject,
+            Permission.PutBucketWebsite,
+            Permission.DeleteObject,
+        ]);
+    });
+
+    const headerTests = [
+        {
+            name: 'html files',
+            path: '/prefixed/page-2',
+            cacheControl: 'public, max-age=0, must-revalidate',
+            contentType: 'text/html',
+        },
+        {
+            name: 'page-data files',
+            path: '/prefixed/page-data/index/page-data.json',
+            cacheControl: 'public, max-age=0, must-revalidate',
+            contentType: 'application/json',
+        },
+        {
+            name: 'sw.js',
+            path: '/prefixed/sw.js',
+            cacheControl: 'public, max-age=0, must-revalidate',
+            contentType: 'application/javascript',
+        },
+    ];
+
+    headerTests.forEach(t => {
+        test(`caching and content type headers are correctly set for ${t.name}`, async () => {
+            const { path } = t;
+
+            const response = await fetch(`${testingEndpoint}${path}`);
+            expect(response.status, `Error accessing ${testingEndpoint}${path}`).toBe(200);
+            expect(response.headers.get('cache-control'), `Incorrect Cache-Control for ${path}`).toBe(t.cacheControl);
+            expect(response.headers.get('content-type'), `Incorrect Content-Type for ${path}`).toBe(t.contentType);
+        });
+    });
+});


### PR DESCRIPTION
This is an attempt to fix the issue #253. The issue is that `CACHING_PARAMS` are not taking `bucketPrefix` into account, and it leads to failing to set [the recommended caching header](https://www.gatsbyjs.com/docs/caching/) and causing various cache related issues.

Another possible fix was to use un-prefixed path against params [here](https://github.com/jariz/gatsby-plugin-s3/blob/a50b3af292ec61d79012d2229748977f77748964/src/bin.ts#L270), which will just use for example  `sw.js` as path to be matched instead of `prefixed/sw.js`. But I decided not to go that way because it breaks compatibility with existing applications which sets the header params by using its full-path(containing bucketPrefix in its path). Also added some e2e test cases to cover this fix.

Any comments and suggestions are appreciated, thanks. 