### PR TITLE
ErrorDocument with bucketPrefix if specified

### DIFF
--- a/gatsby-plugin-s3/src/bin.ts
+++ b/gatsby-plugin-s3/src/bin.ts
@@ -212,7 +212,7 @@ export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) =
                         Suffix: 'index.html',
                     },
                     ErrorDocument: {
-                        Key: '404.html',
+                        Key: config.bucketPrefix ? `${config.bucketPrefix}/404.html` : '404.html',
                     },
                 },
             };


### PR DESCRIPTION
With `bucketPrefix` option, `404.html` file will be located with key prefix `bucketPrefix`.

I pretty much need this fix in case when we use dynamic routing with pathPreix on s3.
Because s3 doesn't support wildcard Redirection, but with this fix s3 return 404.html correctly. And cause by 404.html include js codes, the site show the dynamic routing page, at least.(Even the html file includes 404 content statically, and not good for SEO)