### PR TITLE
fix: resolve redirect paths containing non-ascii characters

### DIFF
--- a/gatsby-plugin-s3/src/bin.ts
+++ b/gatsby-plugin-s3/src/bin.ts
@@ -300,7 +300,7 @@ export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) =
             uploadQueue.push(
                 asyncify(async () => {
                     const { fromPath, toPath: redirectPath } = redirect;
-                    const redirectLocation = base ? resolveUrl(base, redirectPath) : redirectPath;
+                    const redirectLocation = encodeURI(base ? resolveUrl(base, redirectPath) : redirectPath);
 
                     let key = withoutLeadingSlash(fromPath);
                     if (key.endsWith('/')) {


### PR DESCRIPTION
When using non-ascii characters in a URL, the redirect path fails upon upload. This encodes the URI to use encoded path symbols. For non-ascii paths this will make no change