### PR TITLE
upgrading to proxy-agent 6.3 to avoid vulnerabilities

### DIFF
--- a/gatsby-plugin-s3/package-lock.json
+++ b/gatsby-plugin-s3/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "gatsby-plugin-s3",
-    "version": "0.3.8",
+    "version": "0.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gatsby-plugin-s3",
-            "version": "0.3.8",
+            "version": "0.4.1",
             "license": "MIT",
             "dependencies": {
+                "@babel/polyfill": "^7.8.3",
                 "async": "^2.6.2",
                 "aws-sdk": "^2.814.0",
                 "chalk": "^2.4.1",
@@ -21,7 +22,7 @@
                 "minimatch": "^3.0.4",
                 "ora": "^3.0.0",
                 "pretty-error": "^2.1.1",
-                "proxy-agent": "^4.0.0",
+                "proxy-agent": "^6.3.0",
                 "stream-to-promise": "^2.2.0",
                 "yargs": "^15.4.0"
             },
@@ -29,7 +30,6 @@
                 "gatsby-plugin-s3": "bin.js"
             },
             "devDependencies": {
-                "@babel/polyfill": "^7.8.3",
                 "@snyk/protect": "latest",
                 "@types/async": "^2.4.1",
                 "@types/node": "^12.0.2"
@@ -3161,13 +3161,10 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "engines": {
-                "node": ">= 6"
-            }
+        "node_modules/@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "node_modules/@turist/fetch": {
             "version": "7.2.0",
@@ -3857,19 +3854,19 @@
             "peer": true
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "version": "7.1.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
             "dependencies": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/agent-base/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
@@ -3885,7 +3882,7 @@
         },
         "node_modules/agent-base/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/aggregate-error": {
@@ -4316,7 +4313,7 @@
         },
         "node_modules/ast-types": {
             "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "dependencies": {
                 "tslib": "^2.0.1"
@@ -4332,9 +4329,9 @@
             "peer": true
         },
         "node_modules/ast-types/node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "version": "2.6.2",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
@@ -5191,6 +5188,14 @@
                 "node": "^4.5.0 || >= 5.9"
             }
         },
+        "node_modules/basic-ftp": {
+            "version": "5.0.3",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/basic-ftp/-/basic-ftp-5.0.3.tgz",
+            "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5757,6 +5762,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -7675,11 +7681,11 @@
             }
         },
         "node_modules/data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+            "version": "5.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
+            "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/date-fns": {
@@ -7793,7 +7799,8 @@
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "peer": true
         },
         "node_modules/default-gateway": {
             "version": "4.2.0",
@@ -7910,16 +7917,16 @@
             }
         },
         "node_modules/degenerator": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-            "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+            "version": "5.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "dependencies": {
-                "ast-types": "^0.13.2",
-                "escodegen": "^1.8.1",
-                "esprima": "^4.0.0"
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/del": {
@@ -7997,6 +8004,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8832,88 +8840,32 @@
             }
         },
         "node_modules/escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "version": "2.1.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dependencies": {
                 "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
                 "esgenerate": "bin/esgenerate.js"
             },
             "engines": {
-                "node": ">=4.0"
+                "node": ">=6.0"
             },
             "optionalDependencies": {
                 "source-map": "~0.6.1"
             }
         },
-        "node_modules/escodegen/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/escodegen/node_modules/source-map": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "dependencies": {
-                "prelude-ls": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/eslint": {
@@ -9814,7 +9766,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -10395,7 +10346,8 @@
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "peer": true
         },
         "node_modules/fastparse": {
             "version": "1.1.2",
@@ -10494,14 +10446,6 @@
             },
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-            "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/filesize": {
@@ -11159,18 +11103,6 @@
             "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/ftp": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-            "dependencies": {
-                "readable-stream": "1.1.x",
-                "xregexp": "2.0.0"
-            },
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/function-bind": {
@@ -12526,24 +12458,22 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+            "version": "6.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/get-uri/-/get-uri-6.0.1.tgz",
+            "integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "data-uri-to-buffer": "3",
-                "debug": "4",
-                "file-uri-to-path": "2",
-                "fs-extra": "^8.1.0",
-                "ftp": "^0.3.10"
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^5.0.1",
+                "debug": "^4.3.4",
+                "fs-extra": "^8.1.0"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/get-uri/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
@@ -12559,7 +12489,7 @@
         },
         "node_modules/get-uri/node_modules/fs-extra": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/fs-extra/-/fs-extra-8.1.0.tgz",
             "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -12572,7 +12502,7 @@
         },
         "node_modules/get-uri/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/get-value": {
@@ -13685,6 +13615,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "peer": true,
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -13717,21 +13648,20 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "version": "7.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/http-proxy-agent/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
@@ -13747,7 +13677,7 @@
         },
         "node_modules/http-proxy-agent/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/http-proxy-middleware": {
@@ -13929,20 +13859,20 @@
             "peer": true
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "version": "7.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/https-proxy-agent/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
@@ -13958,7 +13888,7 @@
         },
         "node_modules/https-proxy-agent/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/human-signals": {
@@ -14892,9 +14822,9 @@
             }
         },
         "node_modules/ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+            "version": "1.1.8",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ip/-/ip-1.1.8.tgz",
+            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
         },
         "node_modules/ip-regex": {
             "version": "2.1.0",
@@ -18337,7 +18267,7 @@
         },
         "node_modules/netmask": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
             "engines": {
                 "node": ">= 0.4.0"
@@ -19355,27 +19285,26 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-            "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+            "version": "7.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/pac-proxy-agent/-/pac-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-t4tRAMx0uphnZrio0S0Jw9zg3oDbz1zVhQ/Vy18FjLfP1XOLNUEjaVxYCYRI6NS+BsMBXKIzV6cTLOkO9AtywA==",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4",
-                "get-uri": "3",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "5",
-                "pac-resolver": "^4.1.0",
-                "raw-body": "^2.2.0",
-                "socks-proxy-agent": "5"
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "pac-resolver": "^7.0.0",
+                "socks-proxy-agent": "^8.0.1"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
@@ -19391,20 +19320,20 @@
         },
         "node_modules/pac-proxy-agent/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/pac-resolver": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-            "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+            "version": "7.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/pac-resolver/-/pac-resolver-7.0.0.tgz",
+            "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
             "dependencies": {
-                "degenerator": "^2.2.0",
-                "ip": "^1.1.5",
-                "netmask": "^2.0.1"
+                "degenerator": "^5.0.0",
+                "ip": "^1.1.8",
+                "netmask": "^2.0.2"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/package-json": {
@@ -21129,21 +21058,21 @@
             }
         },
         "node_modules/proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+            "version": "6.3.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/proxy-agent/-/proxy-agent-6.3.0.tgz",
+            "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
             "dependencies": {
-                "agent-base": "^6.0.0",
-                "debug": "4",
-                "http-proxy-agent": "^4.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "lru-cache": "^5.1.1",
-                "pac-proxy-agent": "^4.1.0",
-                "proxy-from-env": "^1.0.0",
-                "socks-proxy-agent": "^5.0.0"
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.0",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.1"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">= 14"
             }
         },
         "node_modules/proxy-agent/node_modules/debug": {
@@ -21163,22 +21092,17 @@
             }
         },
         "node_modules/proxy-agent/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dependencies": {
-                "yallist": "^3.0.2"
+            "version": "7.18.3",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/proxy-agent/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/proxy-agent/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
@@ -21388,6 +21312,7 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
             "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "peer": true,
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -23122,7 +23047,8 @@
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "peer": true
         },
         "node_modules/sha.js": {
             "version": "2.4.11",
@@ -23330,7 +23256,7 @@
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "engines": {
                 "node": ">= 6.0.0",
@@ -23710,11 +23636,11 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-            "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+            "version": "2.7.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
             "dependencies": {
-                "ip": "^1.1.5",
+                "ip": "^2.0.0",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -23723,21 +23649,21 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+            "version": "8.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
+            "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
             "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "4",
-                "socks": "^2.3.3"
+                "agent-base": "^7.0.1",
+                "debug": "^4.3.4",
+                "socks": "^2.7.1"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/socks-proxy-agent/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
@@ -23753,8 +23679,13 @@
         },
         "node_modules/socks-proxy-agent/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/socks/node_modules/ip": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
         },
         "node_modules/sort-keys": {
             "version": "2.0.0",
@@ -24174,6 +24105,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -25147,6 +25079,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "peer": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -25647,6 +25580,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -28061,6 +27995,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -28209,14 +28144,6 @@
             "peer": true,
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/xregexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/xss": {
@@ -30923,10 +30850,10 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
-        "@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+        "@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "@turist/fetch": {
             "version": "7.2.0",
@@ -31514,16 +31441,16 @@
             "peer": true
         },
         "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "version": "7.1.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
             "requires": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
                     "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
@@ -31531,7 +31458,7 @@
                 },
                 "ms": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
@@ -31867,16 +31794,16 @@
         },
         "ast-types": {
             "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "requires": {
                 "tslib": "^2.0.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+                    "version": "2.6.2",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
                 }
             }
         },
@@ -32582,6 +32509,11 @@
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
             "peer": true
         },
+        "basic-ftp": {
+            "version": "5.0.3",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/basic-ftp/-/basic-ftp-5.0.3.tgz",
+            "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g=="
+        },
         "batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -33074,7 +33006,8 @@
         "bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "peer": true
         },
         "cacache": {
             "version": "12.0.4",
@@ -34634,9 +34567,9 @@
             }
         },
         "data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+            "version": "5.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
+            "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg=="
         },
         "date-fns": {
             "version": "2.28.0",
@@ -34718,7 +34651,8 @@
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "peer": true
         },
         "default-gateway": {
             "version": "4.2.0",
@@ -34812,13 +34746,13 @@
             }
         },
         "degenerator": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-            "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+            "version": "5.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "requires": {
-                "ast-types": "^0.13.2",
-                "escodegen": "^1.8.1",
-                "esprima": "^4.0.0"
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
             }
         },
         "del": {
@@ -34882,7 +34816,8 @@
         "depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "peer": true
         },
         "dequal": {
             "version": "2.0.2",
@@ -35582,62 +35517,21 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "version": "2.1.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "requires": {
                 "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
+                "estraverse": "^5.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
-                "estraverse": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
-                },
-                "levn": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                    "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                    }
-                },
-                "optionator": {
-                    "version": "0.8.3",
-                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-                    "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-                    "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.6",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "word-wrap": "~1.2.3"
-                    }
-                },
-                "prelude-ls": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-                },
                 "source-map": {
                     "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "optional": true
-                },
-                "type-check": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                    "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                    "requires": {
-                        "prelude-ls": "~1.1.2"
-                    }
                 }
             }
         },
@@ -36318,8 +36212,7 @@
         "estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "peer": true
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         },
         "estree-util-is-identifier-name": {
             "version": "2.0.0",
@@ -36788,7 +36681,8 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "peer": true
         },
         "fastparse": {
             "version": "1.1.2",
@@ -36869,11 +36763,6 @@
                     }
                 }
             }
-        },
-        "file-uri-to-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-            "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
         },
         "filesize": {
             "version": "3.5.11",
@@ -37432,15 +37321,6 @@
             "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
             "optional": true,
             "peer": true
-        },
-        "ftp": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-            "requires": {
-                "readable-stream": "1.1.x",
-                "xregexp": "2.0.0"
-            }
         },
         "function-bind": {
             "version": "1.1.1",
@@ -38514,21 +38394,19 @@
             }
         },
         "get-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+            "version": "6.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/get-uri/-/get-uri-6.0.1.tgz",
+            "integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
             "requires": {
-                "@tootallnate/once": "1",
-                "data-uri-to-buffer": "3",
-                "debug": "4",
-                "file-uri-to-path": "2",
-                "fs-extra": "^8.1.0",
-                "ftp": "^0.3.10"
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^5.0.1",
+                "debug": "^4.3.4",
+                "fs-extra": "^8.1.0"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
                     "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
@@ -38536,7 +38414,7 @@
                 },
                 "fs-extra": {
                     "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/fs-extra/-/fs-extra-8.1.0.tgz",
                     "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
                     "requires": {
                         "graceful-fs": "^4.2.0",
@@ -38546,7 +38424,7 @@
                 },
                 "ms": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
@@ -39442,6 +39320,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "peer": true,
             "requires": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -39476,18 +39355,17 @@
             }
         },
         "http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "version": "7.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
             "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
                     "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
@@ -39495,7 +39373,7 @@
                 },
                 "ms": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
@@ -39647,17 +39525,17 @@
             "peer": true
         },
         "https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "version": "7.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
             "requires": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
                     "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
@@ -39665,7 +39543,7 @@
                 },
                 "ms": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
@@ -40393,9 +40271,9 @@
             }
         },
         "ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+            "version": "1.1.8",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ip/-/ip-1.1.8.tgz",
+            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
         },
         "ip-regex": {
             "version": "2.1.0",
@@ -42944,7 +42822,7 @@
         },
         "netmask": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
         },
         "newline-regex": {
@@ -43760,24 +43638,23 @@
             "peer": true
         },
         "pac-proxy-agent": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-            "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+            "version": "7.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/pac-proxy-agent/-/pac-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-t4tRAMx0uphnZrio0S0Jw9zg3oDbz1zVhQ/Vy18FjLfP1XOLNUEjaVxYCYRI6NS+BsMBXKIzV6cTLOkO9AtywA==",
             "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4",
-                "get-uri": "3",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "5",
-                "pac-resolver": "^4.1.0",
-                "raw-body": "^2.2.0",
-                "socks-proxy-agent": "5"
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "pac-resolver": "^7.0.0",
+                "socks-proxy-agent": "^8.0.1"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
                     "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
@@ -43785,19 +43662,19 @@
                 },
                 "ms": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
         },
         "pac-resolver": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-            "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+            "version": "7.0.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/pac-resolver/-/pac-resolver-7.0.0.tgz",
+            "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
             "requires": {
-                "degenerator": "^2.2.0",
-                "ip": "^1.1.5",
-                "netmask": "^2.0.1"
+                "degenerator": "^5.0.0",
+                "ip": "^1.1.8",
+                "netmask": "^2.0.2"
             }
         },
         "package-json": {
@@ -45258,18 +45135,18 @@
             }
         },
         "proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+            "version": "6.3.0",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/proxy-agent/-/proxy-agent-6.3.0.tgz",
+            "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
             "requires": {
-                "agent-base": "^6.0.0",
-                "debug": "4",
-                "http-proxy-agent": "^4.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "lru-cache": "^5.1.1",
-                "pac-proxy-agent": "^4.1.0",
-                "proxy-from-env": "^1.0.0",
-                "socks-proxy-agent": "^5.0.0"
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.0",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -45281,22 +45158,14 @@
                     }
                 },
                 "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-                    "requires": {
-                        "yallist": "^3.0.2"
-                    }
+                    "version": "7.18.3",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/lru-cache/-/lru-cache-7.18.3.tgz",
+                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
                 },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
                 }
             }
         },
@@ -45469,6 +45338,7 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
             "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "peer": true,
             "requires": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -46866,7 +46736,8 @@
         "setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "peer": true
         },
         "sha.js": {
             "version": "2.4.11",
@@ -47045,7 +46916,7 @@
         },
         "smart-buffer": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
         },
         "snapdragon": {
@@ -47391,27 +47262,34 @@
             }
         },
         "socks": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-            "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+            "version": "2.7.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
             "requires": {
-                "ip": "^1.1.5",
+                "ip": "^2.0.0",
                 "smart-buffer": "^4.2.0"
+            },
+            "dependencies": {
+                "ip": {
+                    "version": "2.0.0",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ip/-/ip-2.0.0.tgz",
+                    "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+                }
             }
         },
         "socks-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+            "version": "8.0.1",
+            "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
+            "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
             "requires": {
-                "agent-base": "^6.0.2",
-                "debug": "4",
-                "socks": "^2.3.3"
+                "agent-base": "^7.0.1",
+                "debug": "^4.3.4",
+                "socks": "^2.7.1"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/debug/-/debug-4.3.4.tgz",
                     "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
@@ -47419,7 +47297,7 @@
                 },
                 "ms": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "resolved": "https://artifactory.global.square/artifactory/api/npm/square-npm/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
@@ -47771,7 +47649,8 @@
         "statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "peer": true
         },
         "stream-browserify": {
             "version": "2.0.2",
@@ -48562,7 +48441,8 @@
         "toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "peer": true
         },
         "tough-cookie": {
             "version": "2.5.0",
@@ -48937,7 +48817,8 @@
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "peer": true
         },
         "unquote": {
             "version": "1.1.1",
@@ -50921,7 +50802,8 @@
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "peer": true
         },
         "worker-farm": {
             "version": "1.7.0",
@@ -51032,11 +50914,6 @@
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
             "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
             "peer": true
-        },
-        "xregexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
         },
         "xss": {
             "version": "1.0.11",

--- a/gatsby-plugin-s3/package.json
+++ b/gatsby-plugin-s3/package.json
@@ -54,7 +54,7 @@
         "minimatch": "^3.0.4",
         "ora": "^3.0.0",
         "pretty-error": "^2.1.1",
-        "proxy-agent": "^4.0.0",
+        "proxy-agent": "^6.3.0",
         "stream-to-promise": "^2.2.0",
         "yargs": "^15.4.0"
     },

--- a/gatsby-plugin-s3/src/bin.ts
+++ b/gatsby-plugin-s3/src/bin.ts
@@ -23,8 +23,8 @@ import { config as awsConfig } from 'aws-sdk';
 import { createHash } from 'crypto';
 import isCI from 'is-ci';
 import { getS3WebsiteDomainUrl, withoutLeadingSlash } from './util';
-import { AsyncFunction, asyncify, parallelLimit } from 'async';
-import proxy from 'proxy-agent';
+import { AsyncFunction, asyncify, parallelLimit,  } from 'async';
+import { ProxyAgent } from 'proxy-agent';
 
 const pe = new PrettyError();
 
@@ -133,12 +133,16 @@ export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) =
         let httpOptions = {};
         if (process.env.HTTP_PROXY) {
             httpOptions = {
-                agent: proxy(process.env.HTTP_PROXY),
+                agent: new ProxyAgent({
+                    getProxyForUrl: () => process.env.HTTP_PROXY || ""
+                }),
             };
         }
 
         httpOptions = {
-            agent: process.env.HTTP_PROXY ? proxy(process.env.HTTP_PROXY) : undefined,
+            agent: process.env.HTTP_PROXY ? new ProxyAgent({
+                getProxyForUrl: () => process.env.HTTP_PROXY || ""
+            }) : undefined,
             timeout: config.timeout,
             connectTimeout: config.connectTimeout,
             ...httpOptions,


### PR DESCRIPTION
CVE-2023-37903

I would like to update to `proxy-agent 6.3` to avoid a vuln around older versions of `proxy-agent` that use `vm2` which allows for Remote Code Execution.

Background info: 
vm2 is an open source vm/sandbox for Node.js. In vm2 for versions up to and including 3.9.19, Node.js custom inspect function allows attackers to escape the sandbox and run arbitrary code. This may result in Remote Code Execution, assuming the attacker has arbitrary code execution primitive inside the context of vm2 sandbox. There are no patches and no known workarounds. Users are advised to find an alternative software

I've linked the proxy-agent changelog [here](https://github.com/TooTallNate/proxy-agents/blob/main/packages/proxy-agent/CHANGELOG.md).