### PR TITLE
chore: Upgrade proxy-agent

### DIFF
--- a/gatsby-plugin-s3/package.json
+++ b/gatsby-plugin-s3/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-plugin-s3",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "Enables you to deploy your gatsby site to a S3 bucket.",
     "main": "index.js",
     "bin": {
@@ -54,7 +54,7 @@
         "minimatch": "^3.0.4",
         "ora": "^3.0.0",
         "pretty-error": "^2.1.1",
-        "proxy-agent": "^4.0.0",
+        "proxy-agent": "^6.4.0",
         "stream-to-promise": "^2.2.0",
         "yargs": "^15.4.0"
     },

--- a/gatsby-plugin-s3/src/bin.ts
+++ b/gatsby-plugin-s3/src/bin.ts
@@ -24,7 +24,7 @@ import { createHash } from 'crypto';
 import isCI from 'is-ci';
 import { getS3WebsiteDomainUrl, withoutLeadingSlash } from './util';
 import { AsyncFunction, asyncify, parallelLimit } from 'async';
-import proxy from 'proxy-agent';
+import { ProxyAgent } from 'proxy-agent';
 
 const pe = new PrettyError();
 
@@ -133,12 +133,12 @@ export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) =
         let httpOptions = {};
         if (process.env.HTTP_PROXY) {
             httpOptions = {
-                agent: proxy(process.env.HTTP_PROXY),
+                agent: new ProxyAgent(),
             };
         }
 
         httpOptions = {
-            agent: process.env.HTTP_PROXY ? proxy(process.env.HTTP_PROXY) : undefined,
+            agent: process.env.HTTP_PROXY ? new ProxyAgent() : undefined,
             timeout: config.timeout,
             connectTimeout: config.connectTimeout,
             ...httpOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
             }
         },
         "gatsby-plugin-s3": {
-            "version": "0.3.8",
+            "version": "0.4.2",
             "license": "MIT",
             "dependencies": {
                 "@babel/polyfill": "^7.8.3",
@@ -106,7 +106,7 @@
                 "minimatch": "^3.0.4",
                 "ora": "^3.0.0",
                 "pretty-error": "^2.1.1",
-                "proxy-agent": "^4.0.0",
+                "proxy-agent": "^6.4.0",
                 "stream-to-promise": "^2.2.0",
                 "yargs": "^15.4.0"
             },
@@ -7696,9 +7696,15 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
             "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "node_modules/@turist/fetch": {
             "version": "7.2.0",
@@ -8782,6 +8788,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -9391,7 +9398,7 @@
         },
         "node_modules/ast-types": {
             "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "dependencies": {
                 "tslib": "^2.0.1"
@@ -9406,9 +9413,9 @@
             "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
         },
         "node_modules/ast-types/node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "version": "2.7.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
         },
         "node_modules/astral-regex": {
             "version": "1.0.0",
@@ -10129,6 +10136,14 @@
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
+            }
+        },
+        "node_modules/basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/batch": {
@@ -13140,11 +13155,11 @@
             }
         },
         "node_modules/data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+            "version": "6.0.2",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/data-urls": {
@@ -13657,16 +13672,45 @@
             }
         },
         "node_modules/degenerator": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-            "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+            "version": "5.0.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "dependencies": {
-                "ast-types": "^0.13.2",
-                "escodegen": "^1.8.1",
-                "esprima": "^4.0.0"
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/degenerator/node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/degenerator/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/del": {
@@ -16614,39 +16658,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/ftp": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-            "dependencies": {
-                "readable-stream": "1.1.x",
-                "xregexp": "2.0.0"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/ftp/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "node_modules/ftp/node_modules/readable-stream": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-            }
-        },
-        "node_modules/ftp/node_modules/string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -17978,27 +17989,49 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+            "version": "6.0.3",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "data-uri-to-buffer": "3",
-                "debug": "4",
-                "file-uri-to-path": "2",
-                "fs-extra": "^8.1.0",
-                "ftp": "^0.3.10"
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
-        "node_modules/get-uri/node_modules/file-uri-to-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-            "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
+        "node_modules/get-uri/node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
             "engines": {
-                "node": ">= 6"
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/get-uri/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/get-uri/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/get-value": {
@@ -19103,6 +19136,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
             "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
             "dependencies": {
                 "@tootallnate/once": "1",
                 "agent-base": "6",
@@ -19248,6 +19282,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -20070,6 +20105,28 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
+        "node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/ip-regex": {
             "version": "2.1.0",
@@ -26559,7 +26616,7 @@
         },
         "node_modules/netmask": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
             "engines": {
                 "node": ">= 0.4.0"
@@ -28225,35 +28282,81 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-            "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+            "version": "7.0.2",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4",
-                "get-uri": "3",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "5",
-                "pac-resolver": "^4.1.0",
-                "raw-body": "^2.2.0",
-                "socks-proxy-agent": "5"
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+            "version": "7.0.5",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
+            "version": "8.0.4",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "dependencies": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/pac-resolver": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-            "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+            "version": "7.0.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "dependencies": {
-                "degenerator": "^2.2.0",
-                "ip": "^1.1.5",
-                "netmask": "^2.0.1"
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/package-json": {
@@ -30073,35 +30176,78 @@
             }
         },
         "node_modules/proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+            "version": "6.4.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
             "dependencies": {
-                "agent-base": "^6.0.0",
-                "debug": "4",
-                "http-proxy-agent": "^4.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "lru-cache": "^5.1.1",
-                "pac-proxy-agent": "^4.1.0",
-                "proxy-from-env": "^1.0.0",
-                "socks-proxy-agent": "^5.0.0"
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+            "version": "7.0.5",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/proxy-agent/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dependencies": {
-                "yallist": "^3.0.2"
+            "version": "7.18.3",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
             }
         },
-        "node_modules/proxy-agent/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        "node_modules/proxy-agent/node_modules/socks-proxy-agent": {
+            "version": "8.0.4",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "dependencies": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
@@ -33682,15 +33828,15 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-            "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+            "version": "2.8.3",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "dependencies": {
-                "ip": "^1.1.5",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -33698,6 +33844,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+            "dev": true,
             "dependencies": {
                 "agent-base": "^6.0.2",
                 "debug": "4",
@@ -39242,14 +39389,6 @@
             "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/xregexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/xss": {
@@ -45058,7 +45197,13 @@
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
+        },
+        "@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "@turist/fetch": {
             "version": "7.2.0",
@@ -46041,6 +46186,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "requires": {
                 "debug": "4"
             }
@@ -46515,16 +46661,16 @@
         },
         "ast-types": {
             "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "requires": {
                 "tslib": "^2.0.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+                    "version": "2.7.0",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/tslib/-/tslib-2.7.0.tgz",
+                    "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
                 }
             }
         },
@@ -47090,6 +47236,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+        },
+        "basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="
         },
         "batch": {
             "version": "0.6.1",
@@ -49492,9 +49643,9 @@
             }
         },
         "data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+            "version": "6.0.2",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
         },
         "data-urls": {
             "version": "1.1.0",
@@ -49903,13 +50054,32 @@
             }
         },
         "degenerator": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-            "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+            "version": "5.0.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "requires": {
-                "ast-types": "^0.13.2",
-                "escodegen": "^1.8.1",
-                "esprima": "^4.0.0"
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "dependencies": {
+                "escodegen": {
+                    "version": "2.1.0",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/escodegen/-/escodegen-2.1.0.tgz",
+                    "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+                    "requires": {
+                        "esprima": "^4.0.1",
+                        "estraverse": "^5.2.0",
+                        "esutils": "^2.0.2",
+                        "source-map": "~0.6.1"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "optional": true
+                }
             }
         },
         "del": {
@@ -52222,38 +52392,6 @@
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "optional": true
         },
-        "ftp": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-            "requires": {
-                "readable-stream": "1.1.x",
-                "xregexp": "2.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
-        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -52976,7 +53114,7 @@
                 "minimatch": "^3.0.4",
                 "ora": "^3.0.0",
                 "pretty-error": "^2.1.1",
-                "proxy-agent": "^4.0.0",
+                "proxy-agent": "^6.4.0",
                 "stream-to-promise": "^2.2.0",
                 "yargs": "^15.4.0"
             },
@@ -53631,22 +53769,39 @@
             }
         },
         "get-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+            "version": "6.0.3",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
             "requires": {
-                "@tootallnate/once": "1",
-                "data-uri-to-buffer": "3",
-                "debug": "4",
-                "file-uri-to-path": "2",
-                "fs-extra": "^8.1.0",
-                "ftp": "^0.3.10"
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
             },
             "dependencies": {
-                "file-uri-to-path": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-                    "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
+                "fs-extra": {
+                    "version": "11.2.0",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/fs-extra/-/fs-extra-11.2.0.tgz",
+                    "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.1",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/universalify/-/universalify-2.0.1.tgz",
+                    "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
                 }
             }
         },
@@ -54522,6 +54677,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
             "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
             "requires": {
                 "@tootallnate/once": "1",
                 "agent-base": "6",
@@ -54642,6 +54798,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -55267,6 +55424,27 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "requires": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "dependencies": {
+                "jsbn": {
+                    "version": "1.1.0",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/jsbn/-/jsbn-1.1.0.tgz",
+                    "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+                },
+                "sprintf-js": {
+                    "version": "1.1.3",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/sprintf-js/-/sprintf-js-1.1.3.tgz",
+                    "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+                }
+            }
         },
         "ip-regex": {
             "version": "2.1.0",
@@ -60171,7 +60349,7 @@
         },
         "netmask": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
         },
         "next-tick": {
@@ -61455,29 +61633,65 @@
             }
         },
         "pac-proxy-agent": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-            "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+            "version": "7.0.2",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
             "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4",
-                "get-uri": "3",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "5",
-                "pac-resolver": "^4.1.0",
-                "raw-body": "^2.2.0",
-                "socks-proxy-agent": "5"
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.4"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.1",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "7.0.2",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+                    "requires": {
+                        "agent-base": "^7.1.0",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.5",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+                    "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+                    "requires": {
+                        "agent-base": "^7.0.2",
+                        "debug": "4"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "8.0.4",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+                    "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+                    "requires": {
+                        "agent-base": "^7.1.1",
+                        "debug": "^4.3.4",
+                        "socks": "^2.8.3"
+                    }
+                }
             }
         },
         "pac-resolver": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-            "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+            "version": "7.0.1",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "requires": {
-                "degenerator": "^2.2.0",
-                "ip": "^1.1.5",
-                "netmask": "^2.0.1"
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
             }
         },
         "package-json": {
@@ -63004,32 +63218,60 @@
             }
         },
         "proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+            "version": "6.4.0",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
             "requires": {
-                "agent-base": "^6.0.0",
-                "debug": "4",
-                "http-proxy-agent": "^4.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "lru-cache": "^5.1.1",
-                "pac-proxy-agent": "^4.1.0",
-                "proxy-from-env": "^1.0.0",
-                "socks-proxy-agent": "^5.0.0"
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
             },
             "dependencies": {
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                "agent-base": {
+                    "version": "7.1.1",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
                     "requires": {
-                        "yallist": "^3.0.2"
+                        "debug": "^4.3.4"
                     }
                 },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                "http-proxy-agent": {
+                    "version": "7.0.2",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+                    "requires": {
+                        "agent-base": "^7.1.0",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.5",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+                    "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+                    "requires": {
+                        "agent-base": "^7.0.2",
+                        "debug": "4"
+                    }
+                },
+                "lru-cache": {
+                    "version": "7.18.3",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/lru-cache/-/lru-cache-7.18.3.tgz",
+                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+                },
+                "socks-proxy-agent": {
+                    "version": "8.0.4",
+                    "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+                    "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+                    "requires": {
+                        "agent-base": "^7.1.1",
+                        "debug": "^4.3.4",
+                        "socks": "^2.8.3"
+                    }
                 }
             }
         },
@@ -65905,11 +66147,11 @@
             }
         },
         "socks": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-            "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+            "version": "2.8.3",
+            "resolved": "https://p2.block-artifacts.com/artifactory/api/npm/square-npm/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "requires": {
-                "ip": "^1.1.5",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             }
         },
@@ -65917,6 +66159,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+            "dev": true,
             "requires": {
                 "agent-base": "^6.0.2",
                 "debug": "4",
@@ -70319,11 +70562,6 @@
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
             "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
-        },
-        "xregexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
         },
         "xss": {
             "version": "1.0.11",


### PR DESCRIPTION
### Context

The current version of `proxy-agent` has the package `vm2` as a dependency. `vm2` has a current vulnerability [found here](https://github.com/advisories/GHSA-cchq-frgv-rjh5). Unfortunately `vm2` is [no longer supported](https://www.npmjs.com/package/vm2). The only mitigation is to upgrade `proxy-agent` to a version that no longer relies on `vm2`.

I've upgraded this dependency to the latest version.

### Difference

The main differences between the old and the new `proxy-agent` are:

-  `ProxyAgent` is an attribute of the exported package
-  When creating a new `ProxyAgent` instance we no longer have to pass in the HTTP(S) proxy URL, it is retrieved from the environment variables.

### Issues addressed

https://github.com/gatsby-uc/gatsby-plugin-s3/issues/257